### PR TITLE
2024 Update

### DIFF
--- a/.github/workflows/gh-pages.yaml
+++ b/.github/workflows/gh-pages.yaml
@@ -7,7 +7,7 @@ on:
   pull_request:
 
 jobs:
-  deploy:
+  pages:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .DS_Store
 resources
+public
 .hugo_build.lock


### PR DESCRIPTION
Update copyright footer for 2024. This is almost automatic, just need to trigger a deploy.

While we're in here, update the `.gitignore` to disallow `public/`, since that's a local-dev-only setup that can accidentally get committed.